### PR TITLE
Fix: corrected IP address on ge-0/0/1 from 192.168.1.2 to 10.10.1.1

### DIFF
--- a/fixes/fix-interface-ip.txt
+++ b/fixes/fix-interface-ip.txt
@@ -1,0 +1,5 @@
+# Rollback incorrect IP
+delete interfaces ge-0/0/1 unit 0 family inet address 192.168.1.2/24
+
+# Apply correct IP
+set interfaces ge-0/0/1 unit 0 family inet address 10.10.1.1/24


### PR DESCRIPTION
corrected IP address on ge-0/0/1 from 192.168.1.2 to 10.10.1.1. please take a look at the changes. 